### PR TITLE
Refactor winner selection and randomness sources

### DIFF
--- a/src/CryptoFairPicker/Csprng/CsprngRandomSource.cs
+++ b/src/CryptoFairPicker/Csprng/CsprngRandomSource.cs
@@ -1,4 +1,6 @@
 using System.Security.Cryptography;
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
 
 namespace CryptoFairPicker.Csprng;
 

--- a/src/CryptoFairPicker/Csprng/CsprngWinnerSelector.cs
+++ b/src/CryptoFairPicker/Csprng/CsprngWinnerSelector.cs
@@ -1,61 +1,22 @@
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Services;
+
 namespace CryptoFairPicker.Csprng;
 
 /// <summary>
 /// Implementation of IWinnerSelector using CSPRNG for local randomness.
 /// Provides a fast fallback option when drand is not available.
 /// </summary>
-public class CsprngWinnerSelector : IWinnerSelector
+/// <remarks>
+/// Initializes a new instance of CsprngWinnerSelector.
+/// </remarks>
+/// <param name="randomSource">The fair random source to use for selection.</param>
+public class CsprngWinnerSelector(IFairRandomSource randomSource) : WinnerSelectorBase(randomSource)
 {
-    private readonly IFairRandomSource _randomSource;
-
-    /// <summary>
-    /// Initializes a new instance of CsprngWinnerSelector.
-    /// </summary>
-    /// <param name="randomSource">The fair random source to use for selection.</param>
-    public CsprngWinnerSelector(IFairRandomSource randomSource)
-    {
-        _randomSource = randomSource ?? throw new ArgumentNullException(nameof(randomSource));
-    }
-
     /// <summary>
     /// Initializes a new instance of CsprngWinnerSelector with default CSPRNG source.
     /// </summary>
     public CsprngWinnerSelector() : this(new CsprngRandomSource())
     {
-    }
-
-    /// <inheritdoc />
-    public int PickWinner(int n, RoundId round)
-    {
-        if (n <= 0)
-        {
-            throw new ArgumentException("Number of participants must be positive.", nameof(n));
-        }
-
-        if (round == null)
-        {
-            throw new ArgumentNullException(nameof(round));
-        }
-
-        // Get random value in [0, n) and add 1 to get [1, n]
-        return _randomSource.NextInt(n, round) + 1;
-    }
-
-    /// <inheritdoc />
-    public async Task<int> PickWinnerAsync(int n, RoundId round, CancellationToken cancellationToken = default)
-    {
-        if (n <= 0)
-        {
-            throw new ArgumentException("Number of participants must be positive.", nameof(n));
-        }
-
-        if (round == null)
-        {
-            throw new ArgumentNullException(nameof(round));
-        }
-
-        // Get random value in [0, n) and add 1 to get [1, n]
-        var winner = await _randomSource.NextIntAsync(n, round, cancellationToken);
-        return winner + 1;
     }
 }

--- a/src/CryptoFairPicker/Drand/DrandRandomSource.cs
+++ b/src/CryptoFairPicker/Drand/DrandRandomSource.cs
@@ -1,5 +1,7 @@
 using System.Security.Cryptography;
 using System.Text.Json;
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Retry;

--- a/src/CryptoFairPicker/Drand/DrandWinnerSelector.cs
+++ b/src/CryptoFairPicker/Drand/DrandWinnerSelector.cs
@@ -1,54 +1,16 @@
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Services;
+
 namespace CryptoFairPicker.Drand;
 
 /// <summary>
 /// Implementation of IWinnerSelector using drand randomness beacon.
 /// Selects winners in the range [1, n] using verifiable public randomness.
 /// </summary>
-public class DrandWinnerSelector : IWinnerSelector
+/// <remarks>
+/// Initializes a new instance of DrandWinnerSelector.
+/// </remarks>
+/// <param name="randomSource">The fair random source to use for selection.</param>
+public class DrandWinnerSelector(IFairRandomSource randomSource) : WinnerSelectorBase(randomSource)
 {
-    private readonly IFairRandomSource _randomSource;
-
-    /// <summary>
-    /// Initializes a new instance of DrandWinnerSelector.
-    /// </summary>
-    /// <param name="randomSource">The fair random source to use for selection.</param>
-    public DrandWinnerSelector(IFairRandomSource randomSource)
-    {
-        _randomSource = randomSource ?? throw new ArgumentNullException(nameof(randomSource));
-    }
-
-    /// <inheritdoc />
-    public int PickWinner(int n, RoundId round)
-    {
-        if (n <= 0)
-        {
-            throw new ArgumentException("Number of participants must be positive.", nameof(n));
-        }
-
-        if (round == null)
-        {
-            throw new ArgumentNullException(nameof(round));
-        }
-
-        // Get random value in [0, n) and add 1 to get [1, n]
-        return _randomSource.NextInt(n, round) + 1;
-    }
-
-    /// <inheritdoc />
-    public async Task<int> PickWinnerAsync(int n, RoundId round, CancellationToken cancellationToken = default)
-    {
-        if (n <= 0)
-        {
-            throw new ArgumentException("Number of participants must be positive.", nameof(n));
-        }
-
-        if (round == null)
-        {
-            throw new ArgumentNullException(nameof(round));
-        }
-
-        // Get random value in [0, n) and add 1 to get [1, n]
-        var winner = await _randomSource.NextIntAsync(n, round, cancellationToken);
-        return winner + 1;
-    }
 }

--- a/src/CryptoFairPicker/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CryptoFairPicker/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Services;
 using CryptoFairPicker.Strategies;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace CryptoFairPicker;
+namespace CryptoFairPicker.Extensions;
 
 /// <summary>
 /// Extension methods for registering CryptoFairPicker services with dependency injection.
@@ -49,9 +51,9 @@ public static class ServiceCollectionExtensions
     /// Adds CryptoFairPicker services with the Drand Beacon strategy.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    /// <param name="beaconUrl">Optional custom beacon URL.</param>
+    /// <param name="beaconUrl">Custom beacon URL.</param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddDrandBeaconPicker(this IServiceCollection services, string? beaconUrl = null)
+    public static IServiceCollection AddDrandBeaconPicker(this IServiceCollection services, string beaconUrl)
     {
         services.AddHttpClient<DrandBeaconStrategy>();
         services.AddTransient<IPickerStrategy>(sp =>

--- a/src/CryptoFairPicker/Extensions/WinnerSelectorServiceCollectionExtensions.cs
+++ b/src/CryptoFairPicker/Extensions/WinnerSelectorServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 using CryptoFairPicker.Csprng;
 using CryptoFairPicker.Drand;
+using CryptoFairPicker.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
-namespace CryptoFairPicker;
+namespace CryptoFairPicker.Extensions;
 
 /// <summary>
 /// Extension methods for registering drand and CSPRNG winner selection services with dependency injection.

--- a/src/CryptoFairPicker/Interfaces/IFairPicker.cs
+++ b/src/CryptoFairPicker/Interfaces/IFairPicker.cs
@@ -1,16 +1,16 @@
-namespace CryptoFairPicker;
+namespace CryptoFairPicker.Interfaces;
 
 /// <summary>
-/// Strategy interface for different picking algorithms.
+/// Represents a fair and cryptographically secure picker for selecting winners.
 /// </summary>
-public interface IPickerStrategy
+public interface IFairPicker
 {
     /// <summary>
     /// Picks a single winner index from 0 to optionCount-1.
     /// </summary>
     /// <param name="optionCount">The total number of options to pick from.</param>
     /// <returns>A zero-based index representing the winner.</returns>
-    int Pick(int optionCount);
+    int PickWinner(int optionCount);
 
     /// <summary>
     /// Picks a single winner index from 0 to optionCount-1 asynchronously.
@@ -18,5 +18,5 @@ public interface IPickerStrategy
     /// <param name="optionCount">The total number of options to pick from.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>A zero-based index representing the winner.</returns>
-    Task<int> PickAsync(int optionCount, CancellationToken cancellationToken = default);
+    Task<int> PickWinnerAsync(int optionCount, CancellationToken cancellationToken = default);
 }

--- a/src/CryptoFairPicker/Interfaces/IFairRandomSource.cs
+++ b/src/CryptoFairPicker/Interfaces/IFairRandomSource.cs
@@ -1,4 +1,6 @@
-namespace CryptoFairPicker;
+using CryptoFairPicker.Models;
+
+namespace CryptoFairPicker.Interfaces;
 
 /// <summary>
 /// Represents a source of fair, verifiable randomness for a specific round.

--- a/src/CryptoFairPicker/Interfaces/IPickerStrategy.cs
+++ b/src/CryptoFairPicker/Interfaces/IPickerStrategy.cs
@@ -1,16 +1,16 @@
-namespace CryptoFairPicker;
+namespace CryptoFairPicker.Interfaces;
 
 /// <summary>
-/// Represents a fair and cryptographically secure picker for selecting winners.
+/// Strategy interface for different picking algorithms.
 /// </summary>
-public interface IFairPicker
+public interface IPickerStrategy
 {
     /// <summary>
     /// Picks a single winner index from 0 to optionCount-1.
     /// </summary>
     /// <param name="optionCount">The total number of options to pick from.</param>
     /// <returns>A zero-based index representing the winner.</returns>
-    int PickWinner(int optionCount);
+    int Pick(int optionCount);
 
     /// <summary>
     /// Picks a single winner index from 0 to optionCount-1 asynchronously.
@@ -18,5 +18,5 @@ public interface IFairPicker
     /// <param name="optionCount">The total number of options to pick from.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>A zero-based index representing the winner.</returns>
-    Task<int> PickWinnerAsync(int optionCount, CancellationToken cancellationToken = default);
+    Task<int> PickAsync(int optionCount, CancellationToken cancellationToken = default);
 }

--- a/src/CryptoFairPicker/Interfaces/IWinnerSelector.cs
+++ b/src/CryptoFairPicker/Interfaces/IWinnerSelector.cs
@@ -1,4 +1,6 @@
-namespace CryptoFairPicker;
+using CryptoFairPicker.Models;
+
+namespace CryptoFairPicker.Interfaces;
 
 /// <summary>
 /// Represents a service that selects winners fairly using verifiable randomness.

--- a/src/CryptoFairPicker/Models/RoundId.cs
+++ b/src/CryptoFairPicker/Models/RoundId.cs
@@ -1,4 +1,4 @@
-namespace CryptoFairPicker;
+namespace CryptoFairPicker.Models;
 
 /// <summary>
 /// Represents a unique identifier for a randomness round from a beacon like drand.

--- a/src/CryptoFairPicker/README.md
+++ b/src/CryptoFairPicker/README.md
@@ -18,7 +18,9 @@ A .NET library for transparent, verifiable, and unbiased winner selection. Perfe
 ### Using Drand (Recommended)
 
 ```csharp
-using CryptoFairPicker;
+using CryptoFairPicker.Extensions;
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
 using Microsoft.Extensions.DependencyInjection;
 
 var services = new ServiceCollection();
@@ -35,6 +37,10 @@ Console.WriteLine($"Winner: Participant #{winner}");
 ### Using Local CSPRNG (Fallback)
 
 ```csharp
+using CryptoFairPicker.Extensions;
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
+
 services.AddCryptoFairPickerCsprng();
 var selector = provider.GetRequiredService<IWinnerSelector>();
 var round = RoundId.FromRound(1); // Ignored for CSPRNG
@@ -57,6 +63,8 @@ var winner = await selector.PickWinnerAsync(100, round);
 ```
 
 ```csharp
+using CryptoFairPicker.Extensions;
+
 builder.Services.AddCryptoFairPicker(builder.Configuration);
 ```
 
@@ -73,6 +81,9 @@ Anyone can verify the selection by fetching the same round from drand and reprod
 
 ### IWinnerSelector (Recommended)
 ```csharp
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
+
 int PickWinner(int n, RoundId round);
 Task<int> PickWinnerAsync(int n, RoundId round, CancellationToken ct = default);
 // Returns: Winner in range [1, n] (1-indexed)
@@ -80,6 +91,9 @@ Task<int> PickWinnerAsync(int n, RoundId round, CancellationToken ct = default);
 
 ### IFairRandomSource (Lower-level)
 ```csharp
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
+
 int NextInt(int toExclusive, RoundId round);
 Task<int> NextIntAsync(int toExclusive, RoundId round, CancellationToken ct = default);
 // Returns: Random value in range [0, toExclusive) (0-indexed)
@@ -88,6 +102,9 @@ Task<int> NextIntAsync(int toExclusive, RoundId round, CancellationToken ct = de
 ## Pre-announced Draws
 
 ```csharp
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
+
 // Announce the round publicly BEFORE it's published
 var futureRound = RoundId.FromRound(9500000);
 Console.WriteLine($"Draw will use drand round {futureRound}");

--- a/src/CryptoFairPicker/Services/FairPicker.cs
+++ b/src/CryptoFairPicker/Services/FairPicker.cs
@@ -1,4 +1,6 @@
-namespace CryptoFairPicker;
+using CryptoFairPicker.Interfaces;
+
+namespace CryptoFairPicker.Services;
 
 /// <summary>
 /// Default implementation of IFairPicker that delegates to a strategy.

--- a/src/CryptoFairPicker/Services/WinnerSelectorBase.cs
+++ b/src/CryptoFairPicker/Services/WinnerSelectorBase.cs
@@ -1,0 +1,57 @@
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
+
+namespace CryptoFairPicker.Services;
+
+/// <summary>
+/// Base implementation of IWinnerSelector that wraps an IFairRandomSource.
+/// Provides common winner selection logic by converting 0-indexed random values to 1-indexed winners.
+/// </summary>
+public class WinnerSelectorBase : IWinnerSelector
+{
+    private readonly IFairRandomSource _randomSource;
+
+    /// <summary>
+    /// Initializes a new instance of WinnerSelectorBase.
+    /// </summary>
+    /// <param name="randomSource">The fair random source to use for selection.</param>
+    protected WinnerSelectorBase(IFairRandomSource randomSource)
+    {
+        _randomSource = randomSource ?? throw new ArgumentNullException(nameof(randomSource));
+    }
+
+    /// <inheritdoc />
+    public int PickWinner(int n, RoundId round)
+    {
+        if (n <= 0)
+        {
+            throw new ArgumentException("Number of participants must be positive.", nameof(n));
+        }
+
+        if (round == null)
+        {
+            throw new ArgumentNullException(nameof(round));
+        }
+
+        // Get random value in [0, n) and add 1 to get [1, n]
+        return _randomSource.NextInt(n, round) + 1;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> PickWinnerAsync(int n, RoundId round, CancellationToken cancellationToken = default)
+    {
+        if (n <= 0)
+        {
+            throw new ArgumentException("Number of participants must be positive.", nameof(n));
+        }
+
+        if (round == null)
+        {
+            throw new ArgumentNullException(nameof(round));
+        }
+
+        // Get random value in [0, n) and add 1 to get [1, n]
+        var winner = await _randomSource.NextIntAsync(n, round, cancellationToken);
+        return winner + 1;
+    }
+}

--- a/src/CryptoFairPicker/Strategies/CommitRevealStrategy.cs
+++ b/src/CryptoFairPicker/Strategies/CommitRevealStrategy.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using CryptoFairPicker.Interfaces;
 
 namespace CryptoFairPicker.Strategies;
 

--- a/src/CryptoFairPicker/Strategies/CsprngStrategy.cs
+++ b/src/CryptoFairPicker/Strategies/CsprngStrategy.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using CryptoFairPicker.Interfaces;
 
 namespace CryptoFairPicker.Strategies;
 

--- a/src/CryptoFairPicker/Strategies/DrandBeaconStrategy.cs
+++ b/src/CryptoFairPicker/Strategies/DrandBeaconStrategy.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text.Json;
+using CryptoFairPicker.Interfaces;
 
 namespace CryptoFairPicker.Strategies;
 

--- a/tests/CryptoFairPicker.Tests/Csprng/CsprngRandomSourceTests.cs
+++ b/tests/CryptoFairPicker.Tests/Csprng/CsprngRandomSourceTests.cs
@@ -1,4 +1,5 @@
 using CryptoFairPicker.Csprng;
+using CryptoFairPicker.Models;
 using NUnit.Framework;
 
 namespace CryptoFairPicker.Tests.Csprng;

--- a/tests/CryptoFairPicker.Tests/Csprng/CsprngWinnerSelectorTests.cs
+++ b/tests/CryptoFairPicker.Tests/Csprng/CsprngWinnerSelectorTests.cs
@@ -1,4 +1,5 @@
 using CryptoFairPicker.Csprng;
+using CryptoFairPicker.Models;
 using NUnit.Framework;
 
 namespace CryptoFairPicker.Tests.Csprng;

--- a/tests/CryptoFairPicker.Tests/Drand/DrandRandomSourceTests.cs
+++ b/tests/CryptoFairPicker.Tests/Drand/DrandRandomSourceTests.cs
@@ -1,6 +1,6 @@
 using CryptoFairPicker.Drand;
+using CryptoFairPicker.Models;
 using Microsoft.Extensions.Options;
-using NSubstitute;
 using System.Net;
 using NUnit.Framework;
 

--- a/tests/CryptoFairPicker.Tests/Drand/DrandWinnerSelectorTests.cs
+++ b/tests/CryptoFairPicker.Tests/Drand/DrandWinnerSelectorTests.cs
@@ -1,4 +1,6 @@
 using CryptoFairPicker.Drand;
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Models;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/tests/CryptoFairPicker.Tests/FairPickerTests.cs
+++ b/tests/CryptoFairPicker.Tests/FairPickerTests.cs
@@ -1,3 +1,4 @@
+using CryptoFairPicker.Services;
 using CryptoFairPicker.Strategies;
 using NUnit.Framework;
 

--- a/tests/CryptoFairPicker.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/CryptoFairPicker.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,3 +1,6 @@
+using CryptoFairPicker.Extensions;
+using CryptoFairPicker.Interfaces;
+using CryptoFairPicker.Services;
 using CryptoFairPicker.Strategies;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -73,7 +76,7 @@ public class ServiceCollectionExtensionsTests
         var services = new ServiceCollection();
 
         // Act
-        services.AddDrandBeaconPicker();
+        services.AddDrandBeaconPicker("https://drand.cloudflare.com/dbd1c8e7-9b0c-4a3e-9f5b-8c2e5f1a2b3c");
         var provider = services.BuildServiceProvider();
 
         // Assert


### PR DESCRIPTION
- Introduced a base class `WinnerSelectorBase` to encapsulate common logic for winner selection.
- Updated `CsprngWinnerSelector` and `DrandWinnerSelector` to inherit from `WinnerSelectorBase`.
- Removed redundant code in winner selectors by utilizing the base class.
- Created interfaces `IFairPicker`, `IFairRandomSource`, `IPickerStrategy`, and `IWinnerSelector` for better abstraction.
- Implemented `FairPicker` class to delegate winner selection to a strategy.
- Added `RoundId` model to represent round identifiers.
- Refactored service registration methods into `ServiceCollectionExtensions` for better organization.
- Removed obsolete files related to previous implementations.
- Updated README to reflect new usage patterns and interfaces.